### PR TITLE
Update answer no. 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 ### You want to run a single caching HTTP reverse proxy on GCP for a latency-sensitive website. This specific reverse proxy consumes almost no CPU. You want to have a 30-GB in-memory cache, and need an additional 2 GB of memory for the rest of the processes. You want to minimize cost. How should you run this reverse proxy?
 
-- [x] Create a Cloud Memorystore for Redis instance with 32-GB capacity.
-- [ ] Run it on Compute Engine, and choose a custom instance type with 6 vCPUs and 32 GB of memory.
+- [ ] Create a Cloud Memorystore for Redis instance with 32-GB capacity.
+- [x] Run it on Compute Engine, and choose a custom instance type with 6 vCPUs and 32 GB of memory.
 - [ ] Package it in a container image, and run it on Kubernetes Engine, using n1-standard-32 instances as nodes.
 - [ ] Run it on Compute Engine, choose the instance type n1-standard-1, and add an SSD persistent disk of 32 GB.
 


### PR DESCRIPTION
I believe the best option is to run it on Compute Engine and choose a custom instance type with 6 vCPUs and 32 GB of memory.